### PR TITLE
Add MCP server for local Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# LLM Devbox MCP Server
+
+This repository contains a small server built with [FastMCP](https://pypi.org/project/fastmcp/) that exposes a few tools for interacting with a local [Ollama](https://ollama.com/) instance.
+
+## Commands
+
+- `ping` – simple health‑check returning `{"status": "ok", "message": "pong"}`.
+- `run-inference` – send a prompt to the configured model on the local Ollama server.
+- `list-models` – returns the names of models available via `ollama list`.
+
+All responses include a top‑level `status` field so clients can easily detect success or error conditions.
+
+## Running
+
+Make sure you have Ollama running locally and then start the MCP server:
+
+```bash
+python llm_devbox_server.py
+```
+
+The server communicates using the MCP protocol over `stdio`.

--- a/llm_devbox_server.py
+++ b/llm_devbox_server.py
@@ -1,0 +1,69 @@
+import asyncio
+import json
+from fastmcp import FastMCP
+import httpx
+
+OLLAMA_HOST = "http://localhost:11434"
+DEFAULT_MODEL = "llama3"
+
+server = FastMCP(name="llm-devbox")
+
+@server.tool("ping")
+async def ping() -> dict:
+    """Simple ping command for health checks."""
+    return {"status": "ok", "message": "pong"}
+
+@server.tool("run-inference")
+async def run_inference(prompt: str, model: str | None = None) -> dict:
+    """Run inference using the locally running Ollama server."""
+    if not prompt:
+        return {"status": "error", "error": "prompt is required"}
+
+    model_name = model or DEFAULT_MODEL
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{OLLAMA_HOST}/api/generate",
+                json={"model": model_name, "prompt": prompt},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        return {"status": "ok", "response": data}
+    except Exception as exc:
+        return {"status": "error", "error": str(exc)}
+
+@server.tool("list-models")
+async def list_models() -> dict:
+    """Return the list of available models from Ollama."""
+    cmd = ["ollama", "list", "--json"]
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            err = stderr.decode().strip() or f"return code {proc.returncode}"
+            raise RuntimeError(err)
+        models = []
+        for line in stdout.decode().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+                name = obj.get("name")
+                if name:
+                    models.append(name)
+            except json.JSONDecodeError:
+                continue
+        return {"status": "ok", "models": models}
+    except Exception as exc:
+        return {"status": "error", "error": str(exc)}
+
+def main() -> None:
+    asyncio.run(server.run_stdio_async())
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `llm_devbox_server.py` with `ping`, `run-inference` and new `list-models` tools
- document the commands and status handling in README

## Testing
- `python -m py_compile llm_devbox_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6848910d4710832fb8b3ae9ce654dc7e